### PR TITLE
Compatibility with PG17 beta3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,14 +17,13 @@ jobs:
         os:
         - ubuntu-latest
         postgres-version:
-        - '9.6'
-        - '10'
         - '11'
         - '12'
         - '13'
         - '14'
         - '15'
         - '16'
+        - '17'
 
     steps:
     - uses: actions/checkout@v2

--- a/pg_auth_mon.c
+++ b/pg_auth_mon.c
@@ -628,9 +628,6 @@ pg_auth_mon_internal(PG_FUNCTION_ARGS, pgauthmonVersion api_version)
 
 	LWLockRelease(auth_mon_lock);
 
-	/* clean up and return the tuplestore */
-	tuplestore_donestoring(tupstore);
-
 	rsinfo->returnMode = SFRM_Materialize;
 	rsinfo->setResult = tupstore;
 	rsinfo->setDesc = tupdesc;


### PR DESCRIPTION
Remove tuplestore_donestoring(). It is not needed since 7.4 (https://github.com/postgres/postgres/commit/d61a361d1aef1231db61162d99b635b89c73169d and https://github.com/postgres/postgres/commit/75680c3d805e2323cd437ac567f0677fdfc7b680)